### PR TITLE
Fix offline support from homescreen

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -9,6 +9,7 @@ self.addEventListener('install', e => e.waitUntil((async () => {
 	await static_assets.addAll([
 		// Main page
 		'/',
+		'/?utm_source=homescreen',
 		'index.html',
 
 		'app.webmanifest',


### PR DESCRIPTION
This caches the /?utm_source=homescreen route so opening the app from the homescreen works offline.  Alternatives could be to redirect the url, but I don't know how that would effect analytics.