### PR TITLE
Fix Torch output

### DIFF
--- a/js/index.mjs
+++ b/js/index.mjs
@@ -145,7 +145,7 @@ async function get_torch() {
 				const is_constraint_error = e instanceof DOMException ||
 					(typeof OverconstrainedError !== 'undefined' && e instanceof OverconstrainedError);
 				if (!is_constraint_error) {
-					// Only catch DOMExceptions
+					// Only catch OverConstraint errors.
 					throw e;
 				}
 			}

--- a/js/index.mjs
+++ b/js/index.mjs
@@ -141,11 +141,13 @@ async function get_torch() {
 				await track.applyConstraints({ advanced: [{ torch: false }] });
 				return track;
 			} catch (e) {
-				if (!(e instanceof DOMException)) {
+				track.stop();
+				const is_constraint_error = e instanceof DOMException ||
+					(typeof OverconstrainedError !== 'undefined' && e instanceof OverconstrainedError);
+				if (!is_constraint_error) {
 					// Only catch DOMExceptions
 					throw e;
 				}
-				track.stop();
 			}
 		}
 	}

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 // This service worker will never refetch assets once it's installed the first time.  This means that in order for the app to update, the service worker must change and recache the assets.  Changing this verions number will do that.
-const version = "0.24"
+const version = "0.25"
 const static_cache_name = 'static_assets-' + version;
 
 


### PR DESCRIPTION
Looks like they added a new error type for media constraint errors.

I also moved the track.stop() up so that the media is freed even if an error occurs.  Not sure if that will handle any additional cases, but I think it makes sense.